### PR TITLE
docc github pages redirect

### DIFF
--- a/.github/workflows/docc_deploy.yml
+++ b/.github/workflows/docc_deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Generate DocC documentation
         run: |
-          curl -s https://raw.githubusercontent.com/BinaryBirds/github-workflows/refs/heads/main/scripts/generate-docc.sh | bash -s -- --name ${{ github.event.repository.name }}
+          curl -s https://raw.githubusercontent.com/BinaryBirds/github-workflows/refs/heads/feature/docc-redirect/scripts/generate-docc.sh | bash -s -- --name ${{ github.event.repository.name }}
 
       - name: Upload DocC artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docc_deploy.yml
+++ b/.github/workflows/docc_deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Generate DocC documentation
         run: |
-          curl -s https://raw.githubusercontent.com/BinaryBirds/github-workflows/refs/heads/feature/docc-redirect/scripts/generate-docc.sh | bash -s -- --name ${{ github.event.repository.name }}
+          curl -s https://raw.githubusercontent.com/BinaryBirds/github-workflows/refs/heads/main/scripts/generate-docc.sh | bash -s -- --name ${{ github.event.repository.name }}
 
       - name: Upload DocC artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This workflow handles the generation and deployment of DocC documentation:
 * **Deploys to GitHub Pages**: Uses `actions/deploy-pages@v4` to publish the results.
 * **Target Configuration**: Respects `.docctargetlist` if present.
 
-**Example Usage (Caller Repository):**
+#### Example Usage (Caller Repository)
 
 ```yaml
 jobs:
@@ -289,7 +289,7 @@ Ensures Swift source files contain a consistent, standardized header.
 
 * `.swiftheaderignore` – excludes paths from header validation
 
-**Raw curl examples**
+#### Raw curl examples
 
 _Check only:_
 
@@ -381,7 +381,7 @@ Generates DocC documentation into the `docs/` directory.
 
 * `.docctargetlist` – explicitly defines documented targets
 
-**Raw curl examples**
+#### Raw curl examples
 
 _GitHub Pages output:_
 
@@ -443,7 +443,7 @@ Installs the Swift OpenAPI Generator CLI tool.
 
 _None_
 
-**Raw curl examples**
+#### Raw curl examples
 
 _Latest version:_
 
@@ -532,11 +532,11 @@ Serves OpenAPI documentation locally using Docker.
 * `-n <name>` – container name
 * `-p <host:container>` – port mapping
 
-#### Ignore files**
+#### Ignore files
 
 _None_
 
-#### Raw curl example**
+#### Raw curl example
 
 ```sh
 curl -s $(baseUrl)/run-openapi-docker.sh | bash -s -- -n openapi-preview

--- a/scripts/generate-docc.sh
+++ b/scripts/generate-docc.sh
@@ -170,21 +170,24 @@ auto_detect_targets() {
     done
 }
 
-# GitHub Pages redirect generation
+# Generate GitHub Pages redirects for DocC output
 #
 # Pages source = /docs
-# Guarantees:
-#   /            → /documentation/
-#   /documentation/ works for both single & multi-target
+# Ensures:
+#   /                    → /documentation/
+#   /documentation        → DocC landing page (multi-target)
+#   /documentation        → /documentation/<Target>/index.html (single-target)
 generate_pages_redirects() {
     local DOC_ROOT="$OUTPUT_DIR/documentation"
 
     log "Generating GitHub Pages redirects"
 
-    # Ensure Pages does not invoke Jekyll
+    # Prevent GitHub Pages from invoking Jekyll
     touch "$OUTPUT_DIR/.nojekyll"
 
-    # Always redirect site root → documentation/
+    # ------------------------------------------------------------------
+    # 1. Always redirect site root (/) → documentation/
+    # ------------------------------------------------------------------
     cat > "$OUTPUT_DIR/index.html" <<EOF
     <!DOCTYPE html>
     <html lang="en">
@@ -205,14 +208,18 @@ generate_pages_redirects() {
     </html>
 EOF
 
-    # If DocC already generated documentation/index.html,
-    # this is multi-target and nothing else is needed.
+    # ------------------------------------------------------------------
+    # 2. If DocC already created documentation/index.html
+    #    → multi-target, nothing more to do
+    # ------------------------------------------------------------------
     if [ -f "$DOC_ROOT/index.html" ]; then
-        log "Multi-target DocC detected — using DocC landing page"
+        log "Multi-target DocC detected — using DocC-generated landing page"
         return 0
     fi
 
-    # Single target → generate documentation/index.html redirect
+    # ------------------------------------------------------------------
+    # 3. Single-target → generate documentation/index.html redirect
+    # ------------------------------------------------------------------
     local TARGET
     TARGET=$(ls -d "$DOC_ROOT"/*/ 2>/dev/null | head -n 1 | xargs basename)
 
@@ -240,7 +247,7 @@ EOF
     </html>
 EOF
 
-    log "Single-target documentation redirect generated → documentation/$TARGET/index.html"
+    log "Single-target redirect generated → documentation/$TARGET/index.html"
 }
 
 # Target selection


### PR DESCRIPTION
GH_PAGE_URL = `https://<username>.github.io/<repository-name>/`

GH pages urls are now redirecting to the documentation path, meaning:
- if multiple target: `GH_PAGE_URL` redirects to `GH_PAGE_URL/documentation`
- if single-target: `GH_PAGE_URL` redirects to `GH_PAGE_URL/documentation` and redirects to `GH_PAGE_URL/documentation/TARGET`


